### PR TITLE
Fix BatteryScheduleHandler methods

### DIFF
--- a/openEMS_PY/energy_schedule_handler.py
+++ b/openEMS_PY/energy_schedule_handler.py
@@ -26,10 +26,16 @@ from initial_population_utils import Transition
 # --------------------------------------------------------------------- #
 @dataclass(slots=True)
 class BatteryScheduleHandler:
-    modes: Sequence[str] = ("CHARGE", "DISCHARGE", "IDLE", "AUTO_PRICE", "AUTO_PV")
-    @property
-    def max_mode_value(self):
-        return len(self.modes) - 1
+    parent_id: str = "battery0"
+
+    # (you could load these from a config file – hard‑coded for the demo)
+    MODES: Sequence[str] = (
+        "CHARGE",        #   0
+        "DISCHARGE",     #   1
+        "IDLE",          #   2
+        "AUTO_PRICE",    #   3
+        "AUTO_PV",       #   4
+    )
 
 
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
- add missing `parent_id` field
- remove duplicate `max_mode_value` and fix API methods

## Testing
- `python -m py_compile openEMS_PY/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6881462897c483269c4a893d9b863f97