### PR TITLE
Fix KPI calculations and add SOC plot

### DIFF
--- a/openEMS_PY/main_simulation.py
+++ b/openEMS_PY/main_simulation.py
@@ -171,7 +171,7 @@ def run_simulation(
         df_res["pv_kwh"] = df_res.pv_kw * 0.25
         df_res["cost_eur"] = df_res.grid_buy_cost - df_res.grid_sell_revenue
         df_res["battery_mode"] = df_res.best_schedule.apply(lambda s: s[0])
-        df_res["batt_to_grid_kwh"] = (-df_res.grid_to_ess.clip(upper=0)).rename("batt_to_grid_kwh")
+        df_res["batt_to_grid_kwh"] = -df_res.grid_to_ess.clip(upper=0)
         df_res["grid_charge_kwh"] = df_res.grid_to_ess.clip(lower=0)
         df_res["soc_kwh"] = soc_history
     return df_res

--- a/openEMS_PY/simulation_results.py
+++ b/openEMS_PY/simulation_results.py
@@ -6,8 +6,9 @@ Dataclass mirroring
 
   • io.openems.edge.energy.optimizer.SimulationResult
 
-Holds the best schedule for a horizon **and** the aggregated KPIs that
-OpenEMS’ UI later visualises.
+The Python port returns the KPIs for **the first 15 minute period** of the
+optimisation horizon.  This allows a rolling simulation where each call only
+executes the earliest step and advances the state of charge accordingly.
 """
 
 from __future__ import annotations
@@ -19,15 +20,20 @@ import numpy as np
 
 @dataclass(slots=True)
 class SimulationResult:
+    """Outcome of one optimisation horizon."""
+
     # -------------- optimisation outcome --------------------------------
     best_schedule: Sequence[int]          # battery mode per Period index
     fitness: float                        # objective (lower = better)
     violated_constraints: int
 
-    # -------------- KPIs (aggregated for the horizon) -------------------
+    # -------------- KPIs for the FIRST period ---------------------------
     grid_buy_cost: float
     grid_sell_revenue: float
     ess_net_kwh: float                     # positive == discharge
+    grid_to_ess: float                    # +charge from grid, −ESS→grid
+    ess_to_cons: float                    # discharge to consumption
+    prod_to_grid: float                   # PV sold to grid
     time: Optional[datetime] = None        # start time of horizon
 
     @property


### PR DESCRIPTION
## Summary
- compute KPIs only for the executed 15min step
- extend `SimulationResult` with additional flow data
- track SoC and grid charge/discharge to show on plots
- print detailed revenue numbers for baseline and optimisation

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile openEMS_PY/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6885e4e68cac8326902fc95ea48f4cad