### PR TITLE
Add configurable plot horizon and tune GA params

### DIFF
--- a/openEMS_PY/simulator.py
+++ b/openEMS_PY/simulator.py
@@ -34,8 +34,9 @@ from openEMS_PY.simulation_results import SimulationResult
 # ---------------------------------------------------------------------------#
 #  GA parameters (keep tiny – Python is slower than Java)                    #
 # ---------------------------------------------------------------------------#
-POP_SIZE = 14
-N_GENERATIONS = 4
+# Slightly larger GA settings to better reflect the Java implementation
+POP_SIZE = 20
+N_GENERATIONS = 8
 CXPB, MUTPB = 0.7, 0.3
 
 


### PR DESCRIPTION
## Summary
- allow specifying plot duration with `--plot-days`
- draw PV production and SoC over arbitrary timeframes
- enlarge GA population and generations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886069d781c832699aae209bf23641c