### PR TITLE
Add PV battery KPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,16 @@ conda install numpy pandas matplotlib scipy pvlib tqdm deap spyder
 spyder
 ```
 12. In spyder open above the green "run" button: Execute -> Configuration per file and under command line option pass the variable "--days 5" setting the simulation horizon. If not set 1 year is simulated
+
+## Simulation Output
+
+Running `main_simulation.py` prints a summary of key performance indicators.
+Alongside the cost figures it now reports total energy exchanged over the
+simulation:
+
+- **Grid→battery** – electricity imported from the grid to charge the battery
+- **Battery→grid** – energy exported from the battery to the grid
+- **PV→battery** – solar generation stored in the battery
+- **Battery→load** – discharge from the battery used to cover consumption
+
+These totals are printed in kilowatt hours at the end of each run.

--- a/openEMS_PY/main_simulation.py
+++ b/openEMS_PY/main_simulation.py
@@ -173,6 +173,7 @@ def run_simulation(
         df_res["battery_mode"] = df_res.best_schedule.apply(lambda s: s[0])
         df_res["batt_to_grid_kwh"] = -df_res.grid_to_ess.clip(upper=0)
         df_res["grid_charge_kwh"] = df_res.grid_to_ess.clip(lower=0)
+        df_res["pv_to_batt_kwh"] = df_res.prod_to_ess
         df_res["soc_kwh"] = soc_history
     return df_res
 
@@ -199,6 +200,11 @@ def kpi_summary(df: pd.DataFrame, system: SystemParameters) -> None:
     print(f"Optimised PV revenue         : {pv_revenue_opt:10.2f} €")
     print(f"Optimised battery revenue    : {batt_revenue_opt:10.2f} €")
     print(f"→ Savings                    : {baseline_cost-df.cost_eur.sum():10.2f} €")
+    print("Energy totals:")
+    print(f"  Grid→battery : {df.grid_charge_kwh.sum():10.2f} kWh")
+    print(f"  Battery→grid : {df.batt_to_grid_kwh.sum():10.2f} kWh")
+    print(f"  PV→battery   : {df.pv_to_batt_kwh.sum():10.2f} kWh")
+    print(f"  Battery→load : {df.ess_to_cons.sum():10.2f} kWh")
     print("Battery mode share:")
     print(df.battery_mode.value_counts(normalize=True).mul(100).round(1).astype(str) + " %")
     print("-----------------------------------------------------------")

--- a/openEMS_PY/simulation_results.py
+++ b/openEMS_PY/simulation_results.py
@@ -32,6 +32,7 @@ class SimulationResult:
     grid_sell_revenue: float
     ess_net_kwh: float                     # positive == discharge
     grid_to_ess: float                    # +charge from grid, −ESS→grid
+    prod_to_ess: float                    # PV charged into ESS
     ess_to_cons: float                    # discharge to consumption
     prod_to_grid: float                   # PV sold to grid
     time: Optional[datetime] = None        # start time of horizon

--- a/openEMS_PY/simulator.py
+++ b/openEMS_PY/simulator.py
@@ -245,6 +245,7 @@ def simulate(ctx: GlobalOptimizationContext) -> SimulationResult:
         grid_sell_revenue=first_flow.grid_sell_revenue,
         ess_net_kwh=first_flow.ess_net,
         grid_to_ess=first_flow.grid_to_ess,
+        prod_to_ess=first_flow.prod_to_ess,
         ess_to_cons=first_flow.ess_to_cons,
         prod_to_grid=first_flow.prod_to_grid,
         time=ctx.periods[0].time,


### PR DESCRIPTION
## Summary
- extend `SimulationResult` with `prod_to_ess`
- propagate PV-to-battery flow in `simulator`
- expose `pv_to_batt_kwh` column and print new energy totals
- document the added KPI outputs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python openEMS_PY/main_simulation.py --days 1 --plot-days 0` *(interrupted after a few steps)*


------
https://chatgpt.com/codex/tasks/task_e_688635f81f608326b236df4c2ac2b3a9